### PR TITLE
update for readthedocs deprecation - version 2

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,5 +1,8 @@
+# Required
+version: 2
+
 build:
-  image: latest
+  os: "ubuntu-22.04"
 python:
   version: 3.8
   pip_install: true


### PR DESCRIPTION
To address items listed [here](https://blog.readthedocs.com/migrate-configuration-v2/).